### PR TITLE
Drop PHP 5.4 support, require 3.0.6 as minimal version of Behat, add stable release of Behat env loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
-    "behat/behat": "3.*",
-    "behat/environment-loader": "dev-master",
+    "php": ">=5.5",
+    "behat/behat": ">=3.0.6",
+    "behat/environment-loader": "1.*",
     "phpunit/phpunit": "4 - 5"
   },
   "autoload": {


### PR DESCRIPTION
Add stable release of Environment Loader and as a result of incompatibility with older versions, drop php 5.4 support and require Behat 3.0.6 at least
