### PR TITLE
Update SoapContext.php

### DIFF
--- a/src/Context/SoapContext.php
+++ b/src/Context/SoapContext.php
@@ -83,6 +83,16 @@ class SoapContext extends RawSoapContext
     {
         $this->sendRequest($function, [$params->getRowsHash()]);
     }
+    
+    /**
+     * Send SOAP request with params as nested array.
+     *
+     * @Given I call SOAP function :function with params as json:
+     */
+    public function iSendRequestWithNestedParamsArray($function, PyStringNode $json)
+    {
+        $this->sendRequest($function, [json_decode('{' . $json . '}', 'true')]);
+    }
 
     /**
      * Send SOAP request with raw body.


### PR DESCRIPTION
I'd like to suggest this improvement for the SoapContext to make possible to pass a nested array of parameters as a replacement or complement for the existing one with a list.

I like to keep the simplicity of just passing parameters without enclosing the full soap request.
