### PR TITLE
Update SoapContext.php

### DIFF
--- a/src/Context/SoapContext.php
+++ b/src/Context/SoapContext.php
@@ -119,6 +119,17 @@ class SoapContext extends RawSoapContext
     }
 
     /**
+     * @Given /^I expect no SOAP exception$/
+     */
+    public function expectNoException()
+    {
+        // Exit with an error because we're not expecting an exception and got one.
+        if (null !== $this->fault) {
+            throw new \RuntimeException('Unexpected \SoapFault exception was thrown!');
+        }
+    }
+
+    /**
      * @Then /^(?:|I )expect SOAP exception(?:| with code "(\d+)")(?:|( and| or)? with message "(.+?)")$/
      */
     public function expectException($code = null, $condition = null, $message = null)


### PR DESCRIPTION
With the current design you apply to check about a soap fault you actually need also a function like that to test that there are not.

It creates inconsistencies in the behat report to get an unexpected soap fault that will be raised in the beforeStep of the next step if this is not this new function or expectException.

Globally the test will be seen as failed but in the detail actually no steps will be mark as failed. It will just show steps are skipped from the one who got the raised exception.
Before step function can't change the success or failure status of the previous step. Neither afterStep can by the way.

So in that current design after each soap call it is required to call steps "I expect no SOAP exception" or "(?:|I )expect SOAP exception(?:| with code "(\d+)")(?:|( and| or)? with message "(.+?)")"
