### PR TITLE
Load extension parameters via simple ContextInitializer instead of EnvironmentLoader.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
     "psr-4": {
       "Behat\\SoapExtension\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Behat\\SoapExtension\\Context\\Bootstrap\\": "tests/bootstrap/"
+    }
   }
 }

--- a/docs/behat.yml
+++ b/docs/behat.yml
@@ -1,7 +1,15 @@
 default:
+  autoload:
+    'YourCompanyName\CustomFeatureContexts\Bootstrap': %paths.base%/docs/bootstrap
   suites:
     default:
       contexts: {}
+    custom:
+      contexts:
+        - YourCompanyName\CustomFeatureContexts\Bootstrap\ExtendedSoapContext:
+            args:
+              a: "Mountain View"
+              b: "Sunnyvale"
   extensions:
     Behat\SoapExtension:
       # An associative array as second argument for \SoapClient::__soapCall().

--- a/docs/bootstrap/ExtendedSoapContext.php
+++ b/docs/bootstrap/ExtendedSoapContext.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace YourCompanyName\CustomFeatureContexts\Bootstrap;
+
+use Behat\SoapExtension\Context\SoapContext;
+use PHPUnit_Framework_Assert as Assertions;
+
+/**
+ * Class ExtendedSoapContext
+ *
+ * Don't forget to add it to composer's autoload!
+ *
+ * @package YourCompanyName\CustomFeatureContexts\Bootstrap
+ */
+class ExtendedSoapContext extends SoapContext
+{
+    /**
+     * @var string
+     */
+    private $a;
+
+    /**
+     * @var string
+     */
+    private $b;
+
+    /**
+     * SetUp necessary arguments for custom usage.
+     *
+     * @param array $args
+     */
+    public function __construct(array $args)
+    {
+        $this->a = $args['a'];
+        $this->b = $args['b'];
+    }
+
+    /**
+     * @param string $c
+     *
+     * @Then /^I want to check that "(.*)" equals to A and not B$/
+     */
+    public function iCheckThatValueEqualsToANotB($c)
+    {
+        Assertions::assertEquals($this->a, $c);
+        Assertions::assertNotEquals($this->b, $c);
+    }
+}

--- a/docs/features/custom_weather_ws.feature
+++ b/docs/features/custom_weather_ws.feature
@@ -1,0 +1,10 @@
+Feature: Simple test example
+  As a SOAP Extension user
+  I want to be able to use my own extended SOAPContext
+  So that I can add additional steps that work in conjunction with the basic SOAPContext functionality
+
+  Scenario: WeatherWS SOAP and custom properties test with predefined A and B
+    Given I am working with SOAP service WSDL "http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL"
+    And I call SOAP function "GetCityForecastByZIP" with params list:
+      | ZIP | 94040 |
+    And I want to check that "Mountain View" equals to A and not B

--- a/src/ServiceContainer/SoapExtension.php
+++ b/src/ServiceContainer/SoapExtension.php
@@ -4,11 +4,12 @@
  */
 namespace Behat\SoapExtension\ServiceContainer;
 
-use Behat\EnvironmentLoader;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Behat\Behat\Context\ServiceContainer\ContextExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Class SoapExtension.
@@ -17,6 +18,8 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
  */
 class SoapExtension implements Extension
 {
+    const SOAP_ID = 'soap.extension';
+
     /**
      * {@inheritdoc}
      */
@@ -37,8 +40,7 @@ class SoapExtension implements Extension
      */
     public function load(ContainerBuilder $container, array $config)
     {
-        $loader = new EnvironmentLoader($this, $container, $config);
-        $loader->load();
+        $this->loadContextInitializer($container, $config);
     }
 
     /**
@@ -63,5 +65,18 @@ class SoapExtension implements Extension
         }
 
         $config->end();
+    }
+
+    /**
+     * Loads context initializer into given Container.
+     *
+     * @param ContainerBuilder $container
+     * @param array $config
+     */
+    private function loadContextInitializer(ContainerBuilder $container, $config)
+    {
+        $definition = new Definition('Behat\SoapExtension\Context\SoapContextInitializer', array($config));
+        $definition->addTag(ContextExtension::INITIALIZER_TAG);
+        $container->setDefinition('soap.context_initializer', $definition);
     }
 }

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -1,7 +1,16 @@
 default:
+  autoload:
+    'Behat\SoapExtension\Context\Bootstrap': %paths.base%/tests/bootstrap
   suites:
     default:
       contexts: {}
+    extended:
+      contexts:
+        - Behat\SoapExtension\Context\Bootstrap\ExtendedSoapContext:
+            args:
+              a: "Mountain View"
+              b: "Sunnyvale"
+
   extensions:
     Behat\SoapExtension:
       # An associative array as second argument for \SoapClient::__soapCall().

--- a/tests/bootstrap/ExtendedSoapContext.php
+++ b/tests/bootstrap/ExtendedSoapContext.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Behat\SoapExtension\Context\Bootstrap;
+
+use Behat\SoapExtension\Context\SoapContext;
+use PHPUnit_Framework_Assert as Assertions;
+
+class ExtendedSoapContext extends SoapContext
+{
+    /**
+     * @var string
+     */
+    private $a;
+
+    /**
+     * @var string
+     */
+    private $b;
+
+    /**
+     * SetUp necessary arguments for custom usage.
+     *
+     * @param array $args
+     */
+    public function __construct(array $args)
+    {
+        $this->a = $args['a'];
+        $this->b = $args['b'];
+    }
+
+    /**
+     * @param string $c
+     *
+     * @Then /^I want to check that "(.*)" equals to A and not B$/
+     */
+    public function iCheckThatValueEqualsToANotB($c)
+    {
+        Assertions::assertEquals($this->a, $c);
+        Assertions::assertNotEquals($this->b, $c);
+    }
+}

--- a/tests/features/extended.feature
+++ b/tests/features/extended.feature
@@ -1,0 +1,10 @@
+Feature: Simple test example
+  As a SOAP Extension user
+  I want to be able to use my own extended SOAPContext
+  So that I can add additional steps that work in conjunction with the basic SOAPContext functionality
+
+  Scenario: WeatherWS SOAP and custom properties test with predefined A and B
+    Given I am working with SOAP service WSDL "http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL"
+    And I call SOAP function "GetCityForecastByZIP" with params list:
+      | ZIP | 94040 |
+    And I want to check that "Mountain View" equals to A and not B


### PR DESCRIPTION
Currently it's not possible to extend SoapContext in custom any FeatureContext. 

It allows us to extend SoapContext in custom FeatureContexts. Otherwise EnvironmentLoader always add SoapContext steps on every test thus causing potential steps duplication in SoapContext and its descendant classes.